### PR TITLE
CI create-release: permission追加

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,7 +8,8 @@ on:
       - .github/workflows/create-release.yml
       - scripts/action/**
       - action.yml
-permissions: read-all
+permissions:
+  contents: write
 jobs:
   create-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/dev-hato/actions-add-to-projects/actions/runs/7791909117/job/21248922609

CI `create-release` のpermissionを追加します。