### PR TITLE
super-linterアップデート

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -62,6 +62,8 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_TYPESCRIPT_STANDARD: false
           VALIDATE_GIT_COMMITLINT: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -54,7 +54,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@ffde3b2b33b745cb612d787f669ef9442b1339a6 # v8.1.0
+        uses: super-linter/super-linter/slim@7bba2eeb89d01dc9bfd93c497477a57e72c83240 # v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main


### PR DESCRIPTION
https://github.com/dev-hato/actions-add-to-projects/pull/1661 をベースにsuper-linterをアップデートします。

https://github.com/dev-hato/actions-add-to-projects/actions/runs/18239823003/job/51940032480?pr=1661#step:6:172

```
  2025-10-04 04:54:28 [WARN]   Biome format and Prettier are both enabled for JSON files, and might conflict with each other. To avoid potential conflicts, keep only one of the two enabled, and disable the other.
```

`BIOME_FORMAT` と `JSON_PRETTIER` を同時に設定しているとコンフリクトが発生するので、現状と差分が発生しない後者のみを適用するようにしています。

また、 `dist` ディレクトリ以下をlintされないよう、 `BIOME_LINT` を無効化しています。