### PR TITLE
fix: TypeScriptのtscエラーを修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "skipLibCheck": true,
     "moduleResolution": "bundler",
-    "isolatedModules": true
+    "isolatedModules": true,
+    "types": ["node"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "isolatedModules": true
   }
 }


### PR DESCRIPTION
https://github.com/dev-hato/actions-add-to-projects/actions/runs/24215003159/job/70693264579?pr=1831

```
Error: tsconfig.json(8,25): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

https://github.com/dev-hato/actions-add-to-projects/actions/runs/24215684711/job/70695520953

```
Error: src/remove_prs_and_issues.ts(5,22): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
```

上記エラーを修正するため、以下を行います。

- TS5107: `moduleResolution: "node"` (node10の別名) が非推奨のため `"bundler"` に変更
- bundler moduleResolutionへの対応:
  - `"types": ["node"]` を追加し `process` グローバル型を明示的に含める