### PR TITLE
app-idの代わりにclient-idを使う

### DIFF
--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -20,7 +20,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }} # zizmor: ignore[secrets-outside-env]
+          client-id: ${{ secrets.PROJECT_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
       - uses: ./
         with:

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -27,7 +27,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }} # zizmor: ignore[secrets-outside-env]
+          client-id: ${{ secrets.PROJECT_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
       - uses: dev-hato/actions-format-json-yml@4cb268945c4c97e2eac4f9f118faccda54a528be # v0.0.101
         with:


### PR DESCRIPTION
https://github.com/dev-hato/actions-add-to-projects/actions/runs/26720567183/job/78746722870#step:7:1

```
Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

上記Warning解消のため、 `app-id` の代わりに `client-id` を使います。